### PR TITLE
fix: clear previous state on real-time updates

### DIFF
--- a/src/app/components/MapComponent.tsx
+++ b/src/app/components/MapComponent.tsx
@@ -59,6 +59,10 @@ const MapComponent = (Map: MapProps) => {
       if (error) {
         console.log({ error: error.message });
       }
+
+      // Clear the busMap
+      Object.keys(busMap).forEach((key) => delete busMap[key]);
+
       data?.forEach((bus) => {
         if (
           !busMap[bus.driver_id] ||


### PR DESCRIPTION
Fix real-time updates to remove the previous state, ensuring old data is cleared and replaced with the latest location updates.
Fixes #33 