### PR TITLE
fix: assign driver_id form user session

### DIFF
--- a/DriverApp/app/(root)/(tabs)/home.tsx
+++ b/DriverApp/app/(root)/(tabs)/home.tsx
@@ -40,7 +40,7 @@ const Home = () => {
       latitude,
       longitude,
       timestamp: new Date().toISOString(),
-      driver_id: 5, // Genarate this!
+      driver_id: session?.user.id,
       bus_id,
     });
 


### PR DESCRIPTION
Updated the logic to get the driver_id from the user session and assign it.